### PR TITLE
Update ISS-Structure.json

### DIFF
--- a/core/config/ISS-Structure.json
+++ b/core/config/ISS-Structure.json
@@ -74,7 +74,7 @@
             },
             {
                 "Description": "Energy value (number)",
-                "unit": "Watts",
+                "unit": "W",
                 "type": "infoNumeric",
                 "value": "",
                 "key": "energy"
@@ -374,7 +374,7 @@
         "params": [
             {
                 "Description": "Current consumption",
-                "unit": "Watts",
+                "unit": "W",
                 "graphable": "false",
                 "type": "infoNumeric",
                 "value": "0",
@@ -542,7 +542,7 @@
             },
             {
                 "Description": "Energy value (number)",
-                "unit": "Watts",
+                "unit": "W",
                 "type": "infoNumeric",
                 "value": "0",
                 "key": "energy"
@@ -688,7 +688,7 @@
             },
             {
                 "Description": "Energy value (number)",
-                "unit": "Watts",
+                "unit": "W",
                 "type": "infoNumeric",
                 "value": "0",
                 "key": "energy"


### PR DESCRIPTION
Les unités ne se mettent pas au pluriel et il s'agit d'harmoniser avec les autres indications de puissance.
Merci pour ce plugin :-)
Je n'ai par contre pas la possibilité de tester ...